### PR TITLE
Fixed camOperator.RequestZoom call to reflect updated signature (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /obj
+.idea

--- a/src/BHCamera.cs
+++ b/src/BHCamera.cs
@@ -39,7 +39,7 @@ namespace SHRestAPI
         {
             var camOperator = Watchman.Get<CamOperator>();
             var taskSource = new TaskCompletionSource<bool>();
-            camOperator.RequestZoom(level, camOperator.GetAttachedCamera().transform.position, duration, new Func<float, float>(Easing.Exponential.Out), () => taskSource.SetResult(true));
+            camOperator.RequestZoom(level, camOperator.GetAttachedCamera().transform.position, duration, new Func<float, float>(Easing.Exponential.Out), CameraInteractionType.Other, () => taskSource.SetResult(true));
             return taskSource.Task;
         }
 


### PR DESCRIPTION
AK changed the arguments of camOperator.RequestZoom again, causing the project to fail to build (and presumably, old versions to fail to run properly). This updates the call while preserving the same functionality by setting the CameraInteractionType to Other, which does not affect the camera zoom style.